### PR TITLE
converted obamenu from python 2 to 3 using 2to3 tool to fix `Invalid output from pipe-menu "obamenu"`

### DIFF
--- a/rcm/server/bin/obamenu
+++ b/rcm/server/bin/obamenu
@@ -107,7 +107,7 @@ def xescape(s):
 
 def process_category(cat, curCats,  appGroups = application_groups,  aliases = group_aliases ):
 	# first process aliases
-	if aliases.has_key(cat):
+	if cat in aliases:
 		if aliases[cat] == "":
 			return ""                               # ignore this one
 		cat = aliases[cat]
@@ -137,7 +137,7 @@ def process_dtfile(dtf,  catDict):  # process this file & extract relevant info
 		# else
 		eqi = l.split('=')
 		if len(eqi) < 2:
-			print "Error: Invalid .desktop line'" + l + "'"
+			print("Error: Invalid .desktop line'" + l + "'")
 			continue
 		# Check what it is ...
 		if eqi[0] == "Name":
@@ -194,9 +194,9 @@ if __name__ == "__main__":
 
     # now, generate jwm menu include
     if simpleOBheader == True:
-        print '<openbox_pipe_menu>'       # magic header
+        print('<openbox_pipe_menu>')       # magic header
     else:
-        print '<?xml version="1.0" encoding="UTF-8" ?><openbox_pipe_menu xmlns="http://openbox.org/"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xsi:schemaLocation="http://openbox.org/" >'       # magic header
+        print('<?xml version="1.0" encoding="UTF-8" ?><openbox_pipe_menu xmlns="http://openbox.org/"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xsi:schemaLocation="http://openbox.org/" >')       # magic header
     appGroupLen = len(application_groups)
     for ag in range(appGroupLen ):
         catList = categoryDict[application_groups[ag]]
@@ -206,7 +206,7 @@ if __name__ == "__main__":
         tmp = getCatIcon(application_groups[ag])
         if tmp != "":
             catStr += "icon=\"%s\"" % tmp
-        print catStr,  ">"
+        print(catStr,  ">")
         for app in catList:
             progStr = "<item "
             progStr += "label=\"%s\" "  % app.Name
@@ -216,7 +216,7 @@ if __name__ == "__main__":
             if app.Terminal == True:
                 progStr += terminal_string + " "
             progStr += "%s]]></command></action></item>"  % app.Exec
-            print progStr
-        print "</menu>"
-    print "</openbox_pipe_menu>"       # magic footer
+            print(progStr)
+        print("</menu>")
+    print("</openbox_pipe_menu>")       # magic footer
     pass # done/debug break


### PR DESCRIPTION
It seems that `obamenu` fails because it is written for python2 while latest RCM servers are installed with python3
<img width="484" height="154" alt="image" src="https://github.com/user-attachments/assets/56d8ee36-3caa-4622-91e9-c80bc533f9d0" />
```shell
$ "<RCM_PATH>/RCM/rcm/server/bin/obamenu"
  File "<RCM_PATH>/RCM/rcm/server/bin/obamenu", line 140
    print "Error: Invalid .desktop line'" + l + "'"
          ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print("Error: Invalid .desktop line'" + l + "'")?
```
I converted the script using `2to3` tool.